### PR TITLE
fix: typo in file path

### DIFF
--- a/detect/ml_train.py
+++ b/detect/ml_train.py
@@ -313,7 +313,7 @@ def main(args: argparse.Namespace, seed=42):
         dataset: Dataset = Dataset.from_json(output_path)  # type: ignore
     else:
         dataset = predict_data(
-            'c3/' + args.input + '_test.csv', output_path, args.test,
+            'hc3/' + args.input + '_test.csv', output_path, args.test,
             device, args.gpt, args.batch_size
         )
     x, y = data_to_xy(dataset)


### PR DESCRIPTION
Hi,

Although most of the paths in the training files are `hc3/`, there is a specific line shown below typed as `c3`. I think this is a typo.

```
        dataset = predict_data(
            'c3/' + args.input + '_test.csv', output_path, args.test,
            device, args.gpt, args.batch_size
        )
```

This pull request fixes the issue and ensures consistency.